### PR TITLE
Add a notice about enabling WebUI branding update

### DIFF
--- a/flags/flags.md
+++ b/flags/flags.md
@@ -64,6 +64,7 @@ In order to modify flags, you must access `chrome://flags`
 * #sharing-desktop-screenshots-edit
 * #sharing-hub-desktop-omnibox
 * #webui-branding-update
+	* Causes UI issues with Brave's settings
 </p></details>
 
 <details><summary>Disabled</summary><p>


### PR DESCRIPTION
On Brave, the settings page UI has a lot of un-necessary spacing and the sidebar is generally a bit messed up with `#webui-branding-update`. Therefore, this pull request adds a notice about this.
![image](https://user-images.githubusercontent.com/65787561/155373227-8d9fb967-dbca-4ed5-b408-3840e00b83fa.png)
![image](https://user-images.githubusercontent.com/65787561/155373472-d8e1f5b9-9c25-4efe-8ab7-35f67298c0ea.png)
